### PR TITLE
Remove Matomo analytics code from includes

### DIFF
--- a/_includes/footer-custom.html
+++ b/_includes/footer-custom.html
@@ -8,7 +8,7 @@
       <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="Email address" required>
       <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
       <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_8b839ff001767633a64dc0cc8_05a5918b4a" tabindex="-1" value=""></div>
-      <div style="display: inline-block"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button btn"{% if site.matomo.goalIds.newsletter %} onclick="javascript:_paq.push(['trackGoal', {{ site.matomo.goalIds.newsletter }}]);"{% endif %}></div>
+      <div style="display: inline-block"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button btn"></div>
     </div>
   </form>
 </div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -35,21 +35,3 @@
   {% include lunr-search-scripts.html %}
 {%- endif -%}
 
-{%- if jekyll.environment == 'production' and site.matomo -%}
-<!-- Matomo -->
-<script type="text/javascript">
-  var _paq = window._paq || [];
-  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(['trackPageView']);
-  _paq.push(['enableLinkTracking']);
-  (function() {
-    var u="//{{ site.matomo.domain }}/";
-    _paq.push(['setTrackerUrl', u+'matomo.php']);
-    _paq.push(['setSiteId', '{{ site.matomo.siteId }}']);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-  })();
-</script>
-<noscript><p><img src="//{{ site.matomo.domain }}/matomo.php?idsite={{ site.matomo.siteId }}&amp;rec=1" style="border:0;" alt="" /></p></noscript>
-<!-- End Matomo Code -->
-{%- endif %}


### PR DESCRIPTION
Removes unused Matomo tracking scripts and goal tracking references. Site now uses only GoatCounter for privacy-focused analytics.

Fixes #14