### PR TITLE
Fix episode artwork appearing on episode page view

### DIFF
--- a/_drafts/2021-08-20-episode-999-derek-wrigley.md
+++ b/_drafts/2021-08-20-episode-999-derek-wrigley.md
@@ -3,7 +3,6 @@ layout: post
 title: '999 &#124; Derek Wrigley OAM: Founding designer & architect, Renaissance man'
 date: '2021-08-20'
 guest: derek_wrigley
-image: /assets/images/episodes/episode-999.jpg
 categories:
   - Episodes
 tags:
@@ -21,6 +20,7 @@ podcast:
     duration: 0
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-999.jpg
   length: 0
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2021-08-20-episode-999-derek-wrigley/2021-08-20-episode-999-derek-wrigley.mp3'

--- a/_posts/2017-05-19-episode-001-max-robinson.md
+++ b/_posts/2017-05-19-episode-001-max-robinson.md
@@ -3,7 +3,6 @@ layout: post
 title: '1 &#124; Max Robinson: London & beyond'
 date: '2017-05-19'
 guest: max_robinson
-image: /assets/images/episodes/episode-001.jpg
 categories:
   - Episodes
 tags:
@@ -20,6 +19,7 @@ podcast:
     duration: 2788
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-001.jpg
   length: 55842535
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2017-05-19-episode-001-max-robinson/2017-05-19-episode-001-max-robinson.mp3'

--- a/_posts/2017-06-02-episode-002-ian-howard.md
+++ b/_posts/2017-06-02-episode-002-ian-howard.md
@@ -3,7 +3,6 @@ layout: post
 title: '2 &#124; Ian Howard: Aristoc & beyond'
 date: '2017-06-02'
 guest: ian_howard
-image: /assets/images/episodes/episode-002.jpg
 categories:
   - Episodes
 tags:
@@ -17,6 +16,7 @@ podcast:
     duration: 5162
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-002.jpg
   length: 103368987
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2017-06-02-episode-002-ian-howard/2017-06-02-episode-002-ian-howard.mp3'

--- a/_posts/2017-08-23-episode-003-david-lancashire.md
+++ b/_posts/2017-08-23-episode-003-david-lancashire.md
@@ -3,7 +3,6 @@ layout: post
 title: '3 &#124; David Lancashire: Artist, designer & illustrator'
 date: '2017-08-23'
 guest: david_lancashire
-image: /assets/images/episodes/episode-003.jpg
 categories:
   - Episodes
 tags:
@@ -20,6 +19,7 @@ podcast:
     duration: 2216
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-003.jpg
   length: 44395107
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2017-08-23-episode-003-david-lancashire/2017-08-23-episode-003-david-lancashire.mp3'

--- a/_posts/2017-10-01-episode-004-ian-howard.md
+++ b/_posts/2017-10-01-episode-004-ian-howard.md
@@ -3,7 +3,6 @@ layout: post
 title: '4 &#124; Ian Howard: International connections'
 date: '2017-10-01'
 guest: ian_howard
-image: /assets/images/episodes/episode-004.jpg
 categories:
   - Episodes
 tags:
@@ -17,6 +16,7 @@ podcast:
     duration: 2811
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-004.jpg
   length: 56302870
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2017-10-01-episode-004-ian-howard/2017-10-01-episode-004-ian-howard.mp3'

--- a/_posts/2017-11-17-episode-005-ted-worsley.md
+++ b/_posts/2017-11-17-episode-005-ted-worsley.md
@@ -3,7 +3,6 @@ layout: post
 title: '5 &#124; Ted Worsley: Industrial designer & educator'
 date: '2017-11-17'
 guest: ted_worsley
-image: /assets/images/episodes/episode-005.jpg
 categories:
   - Episodes
 tags:
@@ -18,6 +17,7 @@ podcast:
     duration: 3404
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-005.jpg
   length: 68165834
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2017-11-17-episode-005-ted-worsley/2017-11-17-episode-005-ted-worsley.mp3'

--- a/_posts/2020-02-03-episode-006-kathy-demos.md
+++ b/_posts/2020-02-03-episode-006-kathy-demos.md
@@ -3,7 +3,6 @@ layout: post
 title: '6 &#124; Kathy Demos: Design director'
 date: '2020-02-03'
 guest: kathy_demos
-image: /assets/images/episodes/episode-006.jpg
 categories:
   - Episodes
 tags:
@@ -19,6 +18,7 @@ podcast:
     duration: 2798
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-006.jpg
   length: 56035482
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2020-02-03-episode-006-kathy-demos/2020-02-03-episode-006-kathy-demos.mp3'

--- a/_posts/2020-02-17-episode-007-roger-putnam.md
+++ b/_posts/2020-02-17-episode-007-roger-putnam.md
@@ -3,7 +3,6 @@ layout: post
 title: '7 &#124; Roger Putnam: Furniture designer'
 date: '2020-02-17'
 guest: roger_putnam
-image: /assets/images/episodes/episode-007.jpg
 categories:
   - Episodes
 tags:
@@ -20,6 +19,7 @@ podcast:
     duration: 1862
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-007.jpg
   length: 37302509
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2020-02-17-episode-007-roger-putnam/2020-02-17-episode-007-roger-putnam.mp3'

--- a/_posts/2021-01-31-episode-008-robert-miller-smith.md
+++ b/_posts/2021-01-31-episode-008-robert-miller-smith.md
@@ -3,7 +3,6 @@ layout: post
 title: '8 &#124; Robert Miller Smith: Dean & design educator'
 date: '2021-01-31'
 guest: robert_miller_smith
-image: /assets/images/episodes/episode-008.jpg
 categories:
   - Episodes
 tags:
@@ -19,6 +18,7 @@ podcast:
     duration: 3880
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-008.jpg
   length: 77695793
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2021-01-31-episode-008-robert-miller-smith/2021-01-31-episode-008-robert-miller-smith.mp3'

--- a/_posts/2021-02-03-episode-009-don-goodwin.md
+++ b/_posts/2021-02-03-episode-009-don-goodwin.md
@@ -3,7 +3,6 @@ layout: post
 title: '9 &#124; Don Goodwin: Conran design director'
 date: '2021-02-03'
 guest: don_goodwin
-image: /assets/images/episodes/episode-009.jpg
 categories:
   - Episodes
 tags:
@@ -20,6 +19,7 @@ podcast:
     duration: 5189
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-009.jpg
   length: 103910658
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2021-02-03-episode-009-don-goodwin/2021-02-03-episode-009-don-goodwin.mp3'

--- a/_posts/2021-08-24-episode-010-david-terry.md
+++ b/_posts/2021-08-24-episode-010-david-terry.md
@@ -3,7 +3,6 @@ layout: post
 title: '10 &#124; David Terry: Industrial Design Council of Australia & industrial designer'
 date: '2021-08-24'
 guest: david_terry
-image: /assets/images/episodes/episode-010.jpg
 categories:
   - Episodes
 tags:
@@ -19,6 +18,7 @@ podcast:
     duration: 3289
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-010.jpg
   length: 37472737
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2021-08-24-episode-010-david-terry/2021-08-24-episode-010-david-terry.mp3'

--- a/_posts/2021-09-13-episode-011-jeff-newman.md
+++ b/_posts/2021-09-13-episode-011-jeff-newman.md
@@ -3,7 +3,6 @@ layout: post
 title: '11 &#124; Jeffrey Newman: Industrial Design Council of Australia'
 date: '2021-09-13'
 guest: jeff_newman
-image: /assets/images/episodes/episode-011.jpg
 categories:
   - Episodes
 tags:
@@ -18,6 +17,7 @@ podcast:
     duration: 3391
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-011.jpg
   length: 67920857
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2021-09-13-episode-011-jeff-newman/2021-09-13-episode-011-jeff-newman.mp3'

--- a/_posts/2021-09-14-episode-012-mary-featherston.md
+++ b/_posts/2021-09-14-episode-012-mary-featherston.md
@@ -3,7 +3,6 @@ layout: post
 title: '12 &#124; Mary Featherston AM: Interior & furniture designer, early childhood environmental designer'
 date: '2021-09-14'
 guest: mary_featherston
-image: /assets/images/episodes/episode-012.jpg
 categories:
   - Episodes
 tags:
@@ -19,6 +18,7 @@ podcast:
     duration: 2780
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-012.jpg
   length: 55679599
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2021-09-14-episode-012-mary-featherston/2021-09-14-episode-012-mary-featherston.mp3'

--- a/_posts/2021-10-26-episode-013-phil-zmood.md
+++ b/_posts/2021-10-26-episode-013-phil-zmood.md
@@ -3,7 +3,6 @@ layout: post
 title: '13 &#124; Phillip Zmood: Automotive designer'
 date: '2021-10-26'
 guest: phil_zmood
-image: /assets/images/episodes/episode-013.jpg
 categories:
   - Episodes
 tags:
@@ -18,6 +17,7 @@ podcast:
     duration: 2899
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-013.jpg
   length: 58062306
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2021-10-26-episode-013-phil-zmood/2021-10-26-episode-013-phil-zmood.mp3'

--- a/_posts/2022-01-14-episode-014-dario-zoureff.md
+++ b/_posts/2022-01-14-episode-014-dario-zoureff.md
@@ -3,7 +3,6 @@ layout: post
 title: '14 &#124; Dario Zoureff: Interior & furniture designer'
 date: '2022-01-14'
 guest: dario_zoureff
-image: /assets/images/episodes/episode-014.jpg
 categories:
   - Episodes
 tags:
@@ -18,6 +17,7 @@ podcast:
     duration: 2496
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-014.jpg
   length: 28478113
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2022-01-14-episode-014-dario-zoureff/2022-01-14-episode-014-dario-zoureff.mp3'

--- a/_posts/2024-06-11-episode-015-colin-wood.md
+++ b/_posts/2024-06-11-episode-015-colin-wood.md
@@ -3,7 +3,6 @@ layout: post
 title: '15 &#124; Colin Wood: Design publisher'
 date: '2024-06-11'
 guest: colin_wood
-image: /assets/images/episodes/episode-015.jpg
 categories:
   - Episodes
 tags:
@@ -17,6 +16,7 @@ podcast:
     duration: 2608
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-015.jpg
   length: 41743070
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2024-06-11-episode-015-colin-wood/2024-06-11-episode-015-colin-wood.mp3'

--- a/_posts/2024-07-11-episode-016-rina-cohen.md
+++ b/_posts/2024-07-11-episode-016-rina-cohen.md
@@ -3,7 +3,6 @@ layout: post
 title: '16 &#124; Rina Cohen: Interior designer'
 date: '2024-07-11'
 guest: rina_cohen
-image: /assets/images/episodes/episode-016.jpg
 categories:
   - Episodes
 tags:
@@ -17,6 +16,7 @@ podcast:
     duration: 1925
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-016.jpg
   length: 37004157
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2024-07-11-episode-016-rina-cohen/2024-07-11-episode-016-rina-cohen.mp3'

--- a/_posts/2025-04-07-episode-017-louise-dann.md
+++ b/_posts/2025-04-07-episode-017-louise-dann.md
@@ -3,7 +3,6 @@ layout: post
 title: '17 &#124; Louise Dann: A journey through design, culture & sustainability'
 date: '2025-04-07'
 guest: louise_dann
-image: /assets/images/episodes/episode-017.jpg
 categories:
   - Episodes
 tags:
@@ -19,6 +18,7 @@ podcast:
     duration: 1280
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-017.jpg
   length: 20492939
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2025-04-07-episode-017-louise-dann/2025-04-07-episode-017-louise-dann.mp3'

--- a/_posts/2025-08-12-episode-018-robyn-lindsey.md
+++ b/_posts/2025-08-12-episode-018-robyn-lindsey.md
@@ -3,7 +3,6 @@ layout: post
 title: '18 &#124; Robyn Lindsey: Designing across retail, corporate & sustainability'
 date: '2025-08-12'
 guest: robyn_lindsey
-image: /assets/images/episodes/episode-018.jpg
 categories:
   - Episodes
 tags:
@@ -19,6 +18,7 @@ podcast:
     duration: 1981
     explicit: 'false'
     block: 'false'
+    image: /assets/images/episodes/episode-018.jpg
   length: 31713210
   type: audio/mpeg
   url: 'https://archive.org/download/designconv-2025-08-12-episode-018-robyn-lindsey/2025-08-12-episode-018-robyn-lindsey.mp3'

--- a/podcast.xml
+++ b/podcast.xml
@@ -53,7 +53,7 @@
       <itunes:duration>{{ post.podcast.itunes.duration }}</itunes:duration>
       <itunes:explicit>{{ post.podcast.itunes.explicit }}</itunes:explicit>
       <itunes:block>{{ post.podcast.itunes.block }}</itunes:block>
-      {% if post.image %}<itunes:image href="{{ post.image | absolute_url }}"/>{% endif %}
+      {% if post.podcast.itunes.image %}<itunes:image href="{{ post.podcast.itunes.image | absolute_url }}"/>{% endif %}
       <!-- Undocumented -->
       <itunes:summary>{{ post.excerpt | strip_html | normalize_whitespace }}</itunes:summary>
       <itunes:keywords>{{ post.tags | join: "," }}</itunes:keywords>

--- a/src/01-build-episode-posts.php
+++ b/src/01-build-episode-posts.php
@@ -72,7 +72,7 @@ foreach ($episodeRecords as $i => $episodeRecord) {
 
         if ($guestPhotoPath && generateEpisodeArtwork($episodeRecord, $guestPhotoPath, $episodeArtworkPath)) {
             $logger->log(LogLevel::INFO, vsprintf('Generated episode artwork %s', [$episodeArtworkFilename]));
-            $frontMatter['image'] = $episodeArtworkUrl;
+            $episodeArtworkGenerated = $episodeArtworkUrl;
         } else {
             $logger->log(LogLevel::WARNING, vsprintf('Could not generate episode artwork for episode %s', [$episodeRecord[F_EPISODE_ID]]));
         }
@@ -106,6 +106,9 @@ foreach ($episodeRecords as $i => $episodeRecord) {
         ),
         'includeInFeed' => $episodeRecord[F_INCLUDE_IN_PODCAST_FEED] ?? false,
     ];
+    if (isset($episodeArtworkGenerated)) {
+        $frontMatter['podcast']['itunes']['image'] = $episodeArtworkGenerated;
+    }
     $frontMatterStr = "---\n" . Yaml::dump($frontMatter, 3, 2) . "---\n";
 
     // Main post content


### PR DESCRIPTION
Move episode artwork path from top-level `image` front matter field to `podcast.itunes.image` to prevent the jekyll-theme-so-simple theme from displaying it as a header image on episode pages.

The podcast feed continues to use the episode-specific artwork correctly.

Fixes #26