### PR TITLE
Add CLI tool for episode data management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 _site
 tmp/
 vendor
+src/.phpunit.cache/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL := help
 
 .PHONY: help install build build-drafts serve serve-drafts \
+        00-episode-data test \
         01-build-episodes 01-build-episodes-force \
         02-encode-mp3s 02-encode-mp3s-force \
         03-tag-mp3s 03-tag-mp3s-force \
@@ -47,6 +48,13 @@ serve: ## Serve Jekyll site locally.
 
 serve-drafts: ## Serve Jekyll site locally including drafts.
 	bundle exec jekyll serve --config _config.yml --drafts --host 0.0.0.0
+
+# Episode data management
+00-episode-data: ## Manage episode data in Airtable (run with args).
+	php src/00-episode-data.php $(ARGS)
+
+test: ## Run PHP unit tests.
+	cd src && ./vendor/bin/phpunit tests/
 
 # Episode processing workflow (run in sequence)
 01-build-episodes: ## Build episode posts from Airtable (skips published).

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 
 .PHONY: help install build build-drafts serve serve-drafts \
-        00-episode-data test \
+        00-episode-data 00-dump test \
         01-build-episodes 01-build-episodes-force \
         02-encode-mp3s 02-encode-mp3s-force \
         03-tag-mp3s 03-tag-mp3s-force \
@@ -52,6 +52,9 @@ serve-drafts: ## Serve Jekyll site locally including drafts.
 # Episode data management
 00-episode-data: ## Manage episode data in Airtable (run with args).
 	php src/00-episode-data.php $(ARGS)
+
+00-dump: ## Dump all episode data to JSON backup.
+	php src/00-episode-data.php dump
 
 test: ## Run PHP unit tests.
 	cd src && ./vendor/bin/phpunit tests/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 
 .PHONY: help install build build-drafts serve serve-drafts \
-        00-episode-data 00-dump test \
+        00-episode-data 00-dump 00-dump-schema test \
         01-build-episodes 01-build-episodes-force \
         02-encode-mp3s 02-encode-mp3s-force \
         03-tag-mp3s 03-tag-mp3s-force \
@@ -55,6 +55,9 @@ serve-drafts: ## Serve Jekyll site locally including drafts.
 
 00-dump: ## Dump all episode data to JSON backup.
 	php src/00-episode-data.php dump
+
+00-dump-schema: ## Dump Airtable base schema to JSON backup.
+	php src/00-episode-data.php dump-schema
 
 test: ## Run PHP unit tests.
 	cd src && ./vendor/bin/phpunit tests/

--- a/src/00-episode-data.php
+++ b/src/00-episode-data.php
@@ -1,0 +1,224 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Armetiz\AirtableSDK\Airtable;
+use josegonzalez\Dotenv\Loader as DotenvLoader;
+use League\CLImate\CLImate;
+
+require __DIR__ . '/bootstrap.php';
+require __DIR__ . '/EpisodeDataCommand.php';
+
+$climate = new CLImate();
+$command = new EpisodeDataCommand();
+
+// Load environment
+(new DotenvLoader(APP_DIR . '/.env'))
+    ->parse()
+    ->toEnv();
+
+$airtable = new Airtable($_ENV['AIRTABLE_KEY'], $_ENV['AIRTABLE_BASE']);
+$table = $_ENV['AIRTABLE_TABLE'];
+
+// Parse command line
+$parsed = $command->parseArgs(array_slice($argv, 1));
+$cmd = $parsed['command'];
+$args = $parsed['args'];
+
+switch ($cmd) {
+    case 'list':
+        listEpisodes($airtable, $table, $climate, $command);
+        break;
+
+    case 'show':
+        if (empty($args[0])) {
+            $climate->error('Usage: 00-episode-data.php show <episodeId>');
+            exit(1);
+        }
+        showEpisode($airtable, $table, $climate, $command, (int) $args[0]);
+        break;
+
+    case 'create':
+        if (empty($args[0])) {
+            $climate->error('Usage: 00-episode-data.php create <episodeId> [guestId]');
+            exit(1);
+        }
+        createEpisode($airtable, $table, $climate, $command, (int) $args[0], $args[1] ?? null);
+        break;
+
+    case 'update':
+    case 'set':
+        if (count($args) < 3) {
+            $climate->error('Usage: 00-episode-data.php update <episodeId> <field> <value>');
+            $climate->out('');
+            $climate->out('Editable fields: ' . implode(', ', $command->getEditableFields()));
+            exit(1);
+        }
+        updateEpisode($airtable, $table, $climate, $command, (int) $args[0], $args[1], $args[2]);
+        break;
+
+    case 'delete':
+        if (empty($args[0])) {
+            $climate->error('Usage: 00-episode-data.php delete <episodeId>');
+            exit(1);
+        }
+        deleteEpisode($airtable, $table, $climate, (int) $args[0]);
+        break;
+
+    case 'fields':
+        $climate->out('<bold>Editable fields:</bold>');
+        foreach ($command->getEditableFields() as $field) {
+            $climate->out("  - $field");
+        }
+        break;
+
+    case 'help':
+    default:
+        showHelp($climate);
+        break;
+}
+
+function showHelp(CLImate $climate): void
+{
+    $climate->out('<bold>Episode Data CLI</bold>');
+    $climate->out('');
+    $climate->out('<bold>Usage:</bold>');
+    $climate->out('  00-episode-data.php <command> [arguments]');
+    $climate->out('');
+    $climate->out('<bold>Commands:</bold>');
+    $climate->out('  list                              List all episodes');
+    $climate->out('  show <episodeId>                  Show details for an episode');
+    $climate->out('  create <episodeId> [guestId]      Create a new episode record');
+    $climate->out('  update <episodeId> <field> <val>  Update a field value');
+    $climate->out('  delete <episodeId>                Delete an episode record');
+    $climate->out('  fields                            List editable fields');
+    $climate->out('  help                              Show this help message');
+    $climate->out('');
+    $climate->out('<bold>Examples:</bold>');
+    $climate->out('  00-episode-data.php list');
+    $climate->out('  00-episode-data.php show 19');
+    $climate->out('  00-episode-data.php create 19 mimmo_cozzolino');
+    $climate->out('  00-episode-data.php update 19 title "Mimmo Cozzolino: Poster art"');
+    $climate->out('  00-episode-data.php update 19 state Draft');
+    $climate->out('  00-episode-data.php update 19 tags "graphic-design,illustration"');
+}
+
+function listEpisodes(Airtable $airtable, string $table, CLImate $climate, EpisodeDataCommand $command): void
+{
+    $climate->out('<bold>Episode List</bold>');
+    $climate->out('');
+
+    try {
+        $records = $airtable->findRecords($table, []);
+        $rows = [];
+
+        foreach ($records as $record) {
+            $rows[] = $command->formatRecordForList($record->getFields());
+        }
+
+        // Sort by episode ID
+        usort($rows, fn($a, $b) => ($a['ID'] ?? 0) <=> ($b['ID'] ?? 0));
+
+        $climate->table($rows);
+    } catch (Exception $e) {
+        $climate->error('Failed to list episodes: ' . $e->getMessage());
+        exit(1);
+    }
+}
+
+function showEpisode(Airtable $airtable, string $table, CLImate $climate, EpisodeDataCommand $command, int $episodeId): void
+{
+    try {
+        $record = $airtable->findRecord($table, [F_EPISODE_ID => $episodeId]);
+
+        if (!$record) {
+            $climate->error("Episode $episodeId not found");
+            exit(1);
+        }
+
+        $fields = $record->getFields();
+        $formatted = $command->formatRecordForShow($fields);
+
+        $climate->out("<bold>Episode $episodeId</bold>");
+        $climate->out('');
+
+        foreach ($formatted as $key => $value) {
+            $climate->out(sprintf('  <bold>%s:</bold> %s', $key, $value));
+        }
+    } catch (Exception $e) {
+        $climate->error('Failed to show episode: ' . $e->getMessage());
+        exit(1);
+    }
+}
+
+function createEpisode(Airtable $airtable, string $table, CLImate $climate, EpisodeDataCommand $command, int $episodeId, ?string $guestId): void
+{
+    // Check if episode already exists
+    try {
+        $existing = $airtable->findRecord($table, [F_EPISODE_ID => $episodeId]);
+        if ($existing) {
+            $climate->error("Episode $episodeId already exists");
+            exit(1);
+        }
+    } catch (Exception $e) {
+        // Record not found is expected
+    }
+
+    $fields = $command->getDefaultFieldsForCreate($episodeId, $guestId);
+
+    try {
+        $airtable->createRecord($table, $fields);
+        $climate->info("Created episode $episodeId");
+
+        // Show the created record
+        showEpisode($airtable, $table, $climate, $command, $episodeId);
+    } catch (Exception $e) {
+        $climate->error('Failed to create episode: ' . $e->getMessage());
+        exit(1);
+    }
+}
+
+function updateEpisode(Airtable $airtable, string $table, CLImate $climate, EpisodeDataCommand $command, int $episodeId, string $field, string $value): void
+{
+    $parsedValue = parseFieldValue($field, $value);
+
+    try {
+        $airtable->updateRecord($table, [F_EPISODE_ID => $episodeId], [$field => $parsedValue]);
+        $climate->info("Updated episode $episodeId: $field = $value");
+
+        // Show the updated record
+        showEpisode($airtable, $table, $climate, $command, $episodeId);
+    } catch (Exception $e) {
+        $climate->error('Failed to update episode: ' . $e->getMessage());
+        exit(1);
+    }
+}
+
+function deleteEpisode(Airtable $airtable, string $table, CLImate $climate, int $episodeId): void
+{
+    try {
+        $record = $airtable->findRecord($table, [F_EPISODE_ID => $episodeId]);
+        if (!$record) {
+            $climate->error("Episode $episodeId not found");
+            exit(1);
+        }
+
+        $fields = $record->getFields();
+        $climate->out("<bold>About to delete:</bold>");
+        $climate->out("  Episode $episodeId: " . ($fields[F_TITLE] ?? '(no title)'));
+        $climate->out('');
+
+        $input = $climate->confirm('Are you sure you want to delete this episode?');
+        if (!$input->confirmed()) {
+            $climate->out('Cancelled');
+            exit(0);
+        }
+
+        $airtable->deleteRecord($table, [F_EPISODE_ID => $episodeId]);
+        $climate->info("Deleted episode $episodeId");
+    } catch (Exception $e) {
+        $climate->error('Failed to delete episode: ' . $e->getMessage());
+        exit(1);
+    }
+}

--- a/src/00-episode-data.php
+++ b/src/00-episode-data.php
@@ -66,6 +66,10 @@ switch ($cmd) {
         deleteEpisode($airtable, $table, $climate, (int) $args[0]);
         break;
 
+    case 'dump':
+        dumpEpisodes($airtable, $table, $climate, $command, $args[0] ?? null);
+        break;
+
     case 'fields':
         $climate->out('<bold>Editable fields:</bold>');
         foreach ($command->getEditableFields() as $field) {
@@ -92,6 +96,7 @@ function showHelp(CLImate $climate): void
     $climate->out('  create <episodeId> [guestId]      Create a new episode record');
     $climate->out('  update <episodeId> <field> <val>  Update a field value');
     $climate->out('  delete <episodeId>                Delete an episode record');
+    $climate->out('  dump [filename]                   Export all episodes to JSON');
     $climate->out('  fields                            List editable fields');
     $climate->out('  help                              Show this help message');
     $climate->out('');
@@ -102,6 +107,8 @@ function showHelp(CLImate $climate): void
     $climate->out('  00-episode-data.php update 19 title "Mimmo Cozzolino: Poster art"');
     $climate->out('  00-episode-data.php update 19 state Draft');
     $climate->out('  00-episode-data.php update 19 tags "graphic-design,illustration"');
+    $climate->out('  00-episode-data.php dump');
+    $climate->out('  00-episode-data.php dump backup.json');
 }
 
 function listEpisodes(Airtable $airtable, string $table, CLImate $climate, EpisodeDataCommand $command): void
@@ -219,6 +226,35 @@ function deleteEpisode(Airtable $airtable, string $table, CLImate $climate, int 
         $climate->info("Deleted episode $episodeId");
     } catch (Exception $e) {
         $climate->error('Failed to delete episode: ' . $e->getMessage());
+        exit(1);
+    }
+}
+
+function dumpEpisodes(Airtable $airtable, string $table, CLImate $climate, EpisodeDataCommand $command, ?string $filename): void
+{
+    try {
+        $records = $airtable->findRecords($table, []);
+        $episodes = [];
+
+        foreach ($records as $record) {
+            $episodes[] = $record->getFields();
+        }
+
+        // Sort by episode ID
+        usort($episodes, fn($a, $b) => ($a[F_EPISODE_ID] ?? 0) <=> ($b[F_EPISODE_ID] ?? 0));
+
+        $dump = $command->formatRecordsForDump($episodes);
+        $json = json_encode($dump, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        // Determine output file
+        $outputFile = $filename ?? $command->getDumpFilename();
+        $outputPath = APP_DIR . '/dumps/' . $outputFile;
+
+        file_put_contents($outputPath, $json);
+
+        $climate->info("Exported " . count($episodes) . " episodes to $outputFile");
+    } catch (Exception $e) {
+        $climate->error('Failed to dump episodes: ' . $e->getMessage());
         exit(1);
     }
 }

--- a/src/00-episode-data.php
+++ b/src/00-episode-data.php
@@ -70,6 +70,10 @@ switch ($cmd) {
         dumpEpisodes($airtable, $table, $climate, $command, $args[0] ?? null);
         break;
 
+    case 'dump-schema':
+        dumpSchema($climate, $command, $args[0] ?? null);
+        break;
+
     case 'fields':
         $climate->out('<bold>Editable fields:</bold>');
         foreach ($command->getEditableFields() as $field) {
@@ -97,6 +101,7 @@ function showHelp(CLImate $climate): void
     $climate->out('  update <episodeId> <field> <val>  Update a field value');
     $climate->out('  delete <episodeId>                Delete an episode record');
     $climate->out('  dump [filename]                   Export all episodes to JSON');
+    $climate->out('  dump-schema [filename]            Export Airtable base schema to JSON');
     $climate->out('  fields                            List editable fields');
     $climate->out('  help                              Show this help message');
     $climate->out('');
@@ -109,6 +114,7 @@ function showHelp(CLImate $climate): void
     $climate->out('  00-episode-data.php update 19 tags "graphic-design,illustration"');
     $climate->out('  00-episode-data.php dump');
     $climate->out('  00-episode-data.php dump backup.json');
+    $climate->out('  00-episode-data.php dump-schema');
 }
 
 function listEpisodes(Airtable $airtable, string $table, CLImate $climate, EpisodeDataCommand $command): void
@@ -228,6 +234,41 @@ function deleteEpisode(Airtable $airtable, string $table, CLImate $climate, int 
         $climate->error('Failed to delete episode: ' . $e->getMessage());
         exit(1);
     }
+}
+
+function dumpSchema(CLImate $climate, EpisodeDataCommand $command, ?string $filename): void
+{
+    $baseId = $_ENV['AIRTABLE_BASE'];
+    $apiKey = $_ENV['AIRTABLE_KEY'];
+    $url = "https://api.airtable.com/v0/meta/bases/{$baseId}/tables";
+
+    $ch = curl_init($url);
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => ["Authorization: Bearer {$apiKey}"],
+    ]);
+
+    $response = curl_exec($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    if ($httpCode !== 200) {
+        $error = json_decode($response, true)['error']['message'] ?? "HTTP $httpCode";
+        $climate->error("Failed to fetch schema: $error");
+        exit(1);
+    }
+
+    $rawSchema = json_decode($response, true);
+    $dump = $command->formatSchemaForDump($rawSchema);
+    $json = json_encode($dump, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+    $outputFile = $filename ?? $command->getSchemaDumpFilename();
+    $outputPath = APP_DIR . '/dumps/' . $outputFile;
+
+    file_put_contents($outputPath, $json);
+
+    $tableCount = count($rawSchema['tables'] ?? []);
+    $climate->info("Exported schema ({$tableCount} tables) to $outputFile");
 }
 
 function dumpEpisodes(Airtable $airtable, string $table, CLImate $climate, EpisodeDataCommand $command, ?string $filename): void

--- a/src/EpisodeDataCommand.php
+++ b/src/EpisodeDataCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/bootstrap.php';
+
+class EpisodeDataCommand
+{
+    private array $editableFields;
+
+    public function __construct()
+    {
+        $this->editableFields = [
+            F_EPISODE_ID,
+            F_SEASON_NUM,
+            F_STATE,
+            F_DATE,
+            F_GUEST_ID,
+            F_TITLE,
+            F_TAGS,
+            F_SHOW_NOTES . '1',
+            F_SHOW_NOTES . '2',
+            F_SHOW_NOTES . '3',
+            F_MP3_EMBED_URL,
+            F_PHOTO_CREDIT,
+            F_INCLUDE_IN_PODCAST_FEED,
+        ];
+    }
+
+    public function getEditableFields(): array
+    {
+        return $this->editableFields;
+    }
+
+    public function parseArgs(array $argv): array
+    {
+        $command = $argv[0] ?? 'help';
+        $args = array_slice($argv, 1);
+
+        return [
+            'command' => $command,
+            'args' => $args,
+        ];
+    }
+
+    public function formatRecordForList(array $fields): array
+    {
+        return [
+            'ID' => $fields[F_EPISODE_ID] ?? '-',
+            'Date' => $fields[F_DATE] ?? '-',
+            'Guest' => $fields[F_GUEST_ID] ?? '-',
+            'Title' => truncate($fields[F_TITLE] ?? '-', 40),
+            'State' => $fields[F_STATE] ?? '-',
+            'Feed' => ($fields[F_INCLUDE_IN_PODCAST_FEED] ?? false) ? 'Yes' : 'No',
+        ];
+    }
+
+    public function formatRecordForShow(array $fields): array
+    {
+        $formatted = [];
+
+        foreach ($fields as $key => $value) {
+            if (is_array($value)) {
+                $formatted[$key] = implode(', ', $value);
+            } elseif (is_bool($value)) {
+                $formatted[$key] = $value ? 'true' : 'false';
+            } elseif ($value === null) {
+                $formatted[$key] = '(empty)';
+            } else {
+                $formatted[$key] = (string) $value;
+            }
+        }
+
+        return $formatted;
+    }
+
+    public function getDefaultFieldsForCreate(int $episodeId, ?string $guestId = null): array
+    {
+        $fields = [
+            F_EPISODE_ID => $episodeId,
+            F_STATE => STATE_DRAFT,
+            F_SEASON_NUM => (int) date('Y'),
+        ];
+
+        if ($guestId !== null) {
+            $fields[F_GUEST_ID] = $guestId;
+        }
+
+        return $fields;
+    }
+}

--- a/src/EpisodeDataCommand.php
+++ b/src/EpisodeDataCommand.php
@@ -101,4 +101,17 @@ class EpisodeDataCommand
     {
         return 'airtable-dump-' . date('Y-m-d\THis') . '.json';
     }
+
+    public function getSchemaDumpFilename(): string
+    {
+        return 'airtable-schema-' . date('Y-m-d\THis') . '.json';
+    }
+
+    public function formatSchemaForDump(array $rawSchema): array
+    {
+        return [
+            'exported_at' => date('c'),
+            'schema' => $rawSchema,
+        ];
+    }
 }

--- a/src/EpisodeDataCommand.php
+++ b/src/EpisodeDataCommand.php
@@ -88,4 +88,17 @@ class EpisodeDataCommand
 
         return $fields;
     }
+
+    public function formatRecordsForDump(array $records): array
+    {
+        return [
+            'exported_at' => date('c'),
+            'episodes' => $records,
+        ];
+    }
+
+    public function getDumpFilename(): string
+    {
+        return 'airtable-dump-' . date('Y-m-d\THis') . '.json';
+    }
 }

--- a/src/README.md
+++ b/src/README.md
@@ -86,6 +86,34 @@ AIRTABLE_TABLE=<your-table-name>
 
 ## Tools
 
+### Episode Data Management
+
+`00-episode-data.php` provides CLI access to Airtable episode records:
+
+```bash
+# List all episodes
+make 00-episode-data ARGS="list"
+
+# Show episode details
+make 00-episode-data ARGS="show 19"
+
+# Create a new episode
+make 00-episode-data ARGS="create 20 new_guest_id"
+
+# Update a field
+make 00-episode-data ARGS="update 19 title 'Guest Name: Episode subtitle'"
+make 00-episode-data ARGS="update 19 tags 'graphic-design,illustration'"
+make 00-episode-data ARGS="update 19 photoCredit 'Photographer Name'"
+
+# Delete an episode
+make 00-episode-data ARGS="delete 19"
+
+# List available fields
+make 00-episode-data ARGS="fields"
+```
+
+### Episode Processing Pipeline
+
 The following tools follow the general pattern of reading episode data
 from Airtable, and processing each episode record in some way.
 
@@ -122,6 +150,12 @@ Episodes are processed based on their `state` field:
 * **Draft** - Processed by tools
 * **Published** - Processed by tools; skipped if `includeInPodcastFeed` is true (use `--force` to override)
 
-## To Do (Deprecated)
+## Testing
 
-This section tracked initial development and is no longer maintained.
+Run PHP unit tests with:
+
+```bash
+make test
+```
+
+Tests are located in `src/tests/` and use PHPUnit 11.

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -259,6 +259,51 @@ function getEpisodeMp3Info(array $episodeRecord, string $origOrEnc = 'enc'): Mp3
  *
  * @return bool True on success, false on failure
  */
+/**
+ * Parses a field value from CLI string input to the appropriate type.
+ *
+ * @param string $field The field name
+ * @param string $value The string value from CLI
+ *
+ * @return mixed The parsed value (bool, int, array, or string)
+ */
+function parseFieldValue(string $field, string $value): mixed
+{
+    // Boolean fields
+    if ($field === F_INCLUDE_IN_PODCAST_FEED) {
+        return in_array(strtolower($value), ['true', '1', 'yes'], true);
+    }
+
+    // Numeric fields
+    if (in_array($field, [F_EPISODE_ID, F_SEASON_NUM], true)) {
+        return (int) $value;
+    }
+
+    // Array fields (comma-separated)
+    if ($field === F_TAGS) {
+        return array_map('trim', explode(',', $value));
+    }
+
+    // String fields
+    return $value;
+}
+
+/**
+ * Truncates a string to a maximum length, adding ellipsis if truncated.
+ *
+ * @param string $string The string to truncate
+ * @param int    $length Maximum length including ellipsis
+ *
+ * @return string The truncated string
+ */
+function truncate(string $string, int $length): string
+{
+    if (strlen($string) <= $length) {
+        return $string;
+    }
+    return substr($string, 0, $length - 3) . '...';
+}
+
 function generateEpisodeArtwork(
     array $episodeRecord,
     string $guestPhotoPath,

--- a/src/composer.json
+++ b/src/composer.json
@@ -14,5 +14,8 @@
     "wapmorgan/mp3info": "^0.1"
   },
   "minimum-stability": "stable",
-  "prefer-stable": true
+  "prefer-stable": true,
+  "require-dev": {
+    "phpunit/phpunit": "^11"
+  }
 }

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c41b422a492d8e86790eb4456133781",
+    "content-hash": "c79a9e1001ad6fe78e3284e2b1405cfd",
     "packages": [
         {
             "name": "adambrett/shell-wrapper",
@@ -964,7 +964,1789 @@
             "time": "2025-04-01T20:51:11+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "11.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.46"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-24T07:01:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T13:52:54+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:07:44+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:08:43+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.55",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-18T12:37:06+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:41:36+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:26:40+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:49:50+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-21T11:55:47+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:12:51+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:57:36+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:58:38+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:00:13+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:01:32+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:42:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:55:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {

--- a/src/dumps/.gitignore
+++ b/src/dumps/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/tests/EpisodeDataTest.php
+++ b/src/tests/EpisodeDataTest.php
@@ -185,4 +185,44 @@ class EpisodeDataTest extends TestCase
         $this->assertSame(19, $defaults[F_EPISODE_ID]);
         $this->assertSame('mimmo_cozzolino', $defaults[F_GUEST_ID]);
     }
+
+    public function testFormatRecordsForDumpReturnsJsonEncodableArray(): void
+    {
+        $command = new EpisodeDataCommand();
+
+        $records = [
+            [
+                F_EPISODE_ID => 1,
+                F_TITLE => 'Test Episode',
+                F_TAGS => ['design', 'art'],
+                F_INCLUDE_IN_PODCAST_FEED => true,
+            ],
+            [
+                F_EPISODE_ID => 2,
+                F_TITLE => 'Another Episode',
+                F_TAGS => ['illustration'],
+                F_INCLUDE_IN_PODCAST_FEED => false,
+            ],
+        ];
+
+        $dump = $command->formatRecordsForDump($records);
+
+        $this->assertIsArray($dump);
+        $this->assertArrayHasKey('exported_at', $dump);
+        $this->assertArrayHasKey('episodes', $dump);
+        $this->assertCount(2, $dump['episodes']);
+
+        // Verify JSON encoding works
+        $json = json_encode($dump, JSON_PRETTY_PRINT);
+        $this->assertNotFalse($json);
+    }
+
+    public function testGetDumpFilenameIncludesTimestamp(): void
+    {
+        $command = new EpisodeDataCommand();
+
+        $filename = $command->getDumpFilename();
+
+        $this->assertMatchesRegularExpression('/^airtable-dump-\d{4}-\d{2}-\d{2}T\d{6}\.json$/', $filename);
+    }
 }

--- a/src/tests/EpisodeDataTest.php
+++ b/src/tests/EpisodeDataTest.php
@@ -225,4 +225,33 @@ class EpisodeDataTest extends TestCase
 
         $this->assertMatchesRegularExpression('/^airtable-dump-\d{4}-\d{2}-\d{2}T\d{6}\.json$/', $filename);
     }
+
+    public function testGetSchemaDumpFilenameIncludesTimestamp(): void
+    {
+        $command = new EpisodeDataCommand();
+
+        $filename = $command->getSchemaDumpFilename();
+
+        $this->assertMatchesRegularExpression('/^airtable-schema-\d{4}-\d{2}-\d{2}T\d{6}\.json$/', $filename);
+    }
+
+    public function testFormatSchemaForDumpWrapsWithMetadata(): void
+    {
+        $command = new EpisodeDataCommand();
+
+        $rawSchema = [
+            'tables' => [
+                ['id' => 'tbl123', 'name' => 'episodes', 'fields' => []],
+            ],
+        ];
+
+        $dump = $command->formatSchemaForDump($rawSchema);
+
+        $this->assertArrayHasKey('exported_at', $dump);
+        $this->assertArrayHasKey('schema', $dump);
+        $this->assertSame($rawSchema, $dump['schema']);
+
+        $json = json_encode($dump, JSON_PRETTY_PRINT);
+        $this->assertNotFalse($json);
+    }
 }

--- a/src/tests/EpisodeDataTest.php
+++ b/src/tests/EpisodeDataTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__ . '/../EpisodeDataCommand.php';
+
+class EpisodeDataTest extends TestCase
+{
+    public function testParseFieldValueReturnsBooleanForIncludeInPodcastFeed(): void
+    {
+        $this->assertTrue(parseFieldValue(F_INCLUDE_IN_PODCAST_FEED, 'true'));
+        $this->assertTrue(parseFieldValue(F_INCLUDE_IN_PODCAST_FEED, '1'));
+        $this->assertTrue(parseFieldValue(F_INCLUDE_IN_PODCAST_FEED, 'yes'));
+        $this->assertFalse(parseFieldValue(F_INCLUDE_IN_PODCAST_FEED, 'false'));
+        $this->assertFalse(parseFieldValue(F_INCLUDE_IN_PODCAST_FEED, '0'));
+        $this->assertFalse(parseFieldValue(F_INCLUDE_IN_PODCAST_FEED, 'no'));
+    }
+
+    public function testParseFieldValueReturnsIntegerForEpisodeId(): void
+    {
+        $this->assertSame(19, parseFieldValue(F_EPISODE_ID, '19'));
+        $this->assertSame(1, parseFieldValue(F_EPISODE_ID, '1'));
+    }
+
+    public function testParseFieldValueReturnsIntegerForSeasonNum(): void
+    {
+        $this->assertSame(2026, parseFieldValue(F_SEASON_NUM, '2026'));
+    }
+
+    public function testParseFieldValueReturnsArrayForTags(): void
+    {
+        $result = parseFieldValue(F_TAGS, 'graphic-design,illustration,poster-art');
+        $this->assertIsArray($result);
+        $this->assertCount(3, $result);
+        $this->assertSame(['graphic-design', 'illustration', 'poster-art'], $result);
+    }
+
+    public function testParseFieldValueTrimsTagWhitespace(): void
+    {
+        $result = parseFieldValue(F_TAGS, 'graphic-design , illustration , poster-art');
+        $this->assertSame(['graphic-design', 'illustration', 'poster-art'], $result);
+    }
+
+    public function testParseFieldValueReturnsStringForTitle(): void
+    {
+        $result = parseFieldValue(F_TITLE, 'Mimmo Cozzolino: Poster art');
+        $this->assertSame('Mimmo Cozzolino: Poster art', $result);
+    }
+
+    public function testParseFieldValueReturnsStringForState(): void
+    {
+        $this->assertSame('Draft', parseFieldValue(F_STATE, 'Draft'));
+        $this->assertSame('Published', parseFieldValue(F_STATE, 'Published'));
+    }
+
+    public function testTruncateReturnsStringUnchangedIfShorterThanLimit(): void
+    {
+        $this->assertSame('Short string', truncate('Short string', 40));
+    }
+
+    public function testTruncateReturnsStringUnchangedIfExactlyAtLimit(): void
+    {
+        $this->assertSame('1234567890', truncate('1234567890', 10));
+    }
+
+    public function testTruncateShortenStringWithEllipsis(): void
+    {
+        $result = truncate('This is a very long string that needs truncation', 20);
+        $this->assertSame('This is a very lo...', $result);
+        $this->assertSame(20, strlen($result));
+    }
+
+    public function testEpisodeDataCommandReturnsAvailableFields(): void
+    {
+        $command = new EpisodeDataCommand();
+        $fields = $command->getEditableFields();
+
+        $this->assertContains(F_EPISODE_ID, $fields);
+        $this->assertContains(F_TITLE, $fields);
+        $this->assertContains(F_STATE, $fields);
+        $this->assertContains(F_TAGS, $fields);
+        $this->assertContains(F_GUEST_ID, $fields);
+    }
+
+    public function testEpisodeDataCommandParsesArguments(): void
+    {
+        $command = new EpisodeDataCommand();
+
+        // Test 'show' command
+        $parsed = $command->parseArgs(['show', '19']);
+        $this->assertSame('show', $parsed['command']);
+        $this->assertSame(['19'], $parsed['args']);
+
+        // Test 'update' command
+        $parsed = $command->parseArgs(['update', '19', 'title', 'New Title']);
+        $this->assertSame('update', $parsed['command']);
+        $this->assertSame(['19', 'title', 'New Title'], $parsed['args']);
+    }
+
+    public function testEpisodeDataCommandDefaultsToHelp(): void
+    {
+        $command = new EpisodeDataCommand();
+
+        $parsed = $command->parseArgs([]);
+        $this->assertSame('help', $parsed['command']);
+    }
+
+    public function testFormatRecordForListReturnsFormattedRow(): void
+    {
+        $command = new EpisodeDataCommand();
+
+        $fields = [
+            F_EPISODE_ID => 19,
+            F_DATE => '2026-02-03',
+            F_GUEST_ID => 'mimmo_cozzolino',
+            F_TITLE => 'Mimmo Cozzolino: Poster art and graphic design',
+            F_STATE => 'Draft',
+            F_INCLUDE_IN_PODCAST_FEED => false,
+        ];
+
+        $row = $command->formatRecordForList($fields);
+
+        $this->assertSame(19, $row['ID']);
+        $this->assertSame('2026-02-03', $row['Date']);
+        $this->assertSame('mimmo_cozzolino', $row['Guest']);
+        $this->assertSame('Draft', $row['State']);
+        $this->assertSame('No', $row['Feed']);
+        // Title should be truncated to 40 chars
+        $this->assertLessThanOrEqual(40, strlen($row['Title']));
+    }
+
+    public function testFormatRecordForShowReturnsAllFields(): void
+    {
+        $command = new EpisodeDataCommand();
+
+        $fields = [
+            F_EPISODE_ID => 19,
+            F_TITLE => 'Test Title',
+            F_TAGS => ['design', 'poster'],
+            F_INCLUDE_IN_PODCAST_FEED => true,
+        ];
+
+        $formatted = $command->formatRecordForShow($fields);
+
+        $this->assertSame('19', $formatted[F_EPISODE_ID]);
+        $this->assertSame('Test Title', $formatted[F_TITLE]);
+        $this->assertSame('design, poster', $formatted[F_TAGS]);
+        $this->assertSame('true', $formatted[F_INCLUDE_IN_PODCAST_FEED]);
+    }
+
+    public function testFormatRecordForShowHandlesEmptyValues(): void
+    {
+        $command = new EpisodeDataCommand();
+
+        $fields = [
+            F_EPISODE_ID => 19,
+            F_TITLE => null,
+        ];
+
+        $formatted = $command->formatRecordForShow($fields);
+
+        $this->assertSame('(empty)', $formatted[F_TITLE]);
+    }
+
+    public function testGetDefaultFieldsForCreate(): void
+    {
+        $command = new EpisodeDataCommand();
+
+        $defaults = $command->getDefaultFieldsForCreate(19);
+
+        $this->assertSame(19, $defaults[F_EPISODE_ID]);
+        $this->assertSame(STATE_DRAFT, $defaults[F_STATE]);
+        $this->assertSame((int) date('Y'), $defaults[F_SEASON_NUM]);
+    }
+
+    public function testGetDefaultFieldsForCreateWithGuestId(): void
+    {
+        $command = new EpisodeDataCommand();
+
+        $defaults = $command->getDefaultFieldsForCreate(19, 'mimmo_cozzolino');
+
+        $this->assertSame(19, $defaults[F_EPISODE_ID]);
+        $this->assertSame('mimmo_cozzolino', $defaults[F_GUEST_ID]);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `00-episode-data.php` CLI tool for managing Airtable episode records
- Add `EpisodeDataCommand` class with unit-tested methods
- Add PHPUnit 11 test suite with 22 tests

## Commands

```bash
make 00-episode-data ARGS="list"                    # List all episodes
make 00-episode-data ARGS="show 19"                 # Show episode details
make 00-episode-data ARGS="create 20 guest_id"      # Create new episode
make 00-episode-data ARGS="update 19 title 'Title'" # Update a field
make 00-episode-data ARGS="delete 19"               # Delete episode
make 00-episode-data ARGS="dump"                    # Export data to JSON
make 00-episode-data ARGS="dump-schema"             # Export base schema to JSON
make 00-episode-data ARGS="fields"                  # List editable fields

make 00-dump                                        # Quick data backup
make 00-dump-schema                                 # Quick schema backup
```

## Test plan

- [x] `make test` passes (22 tests, 58 assertions)
- [x] `make 00-episode-data ARGS="list"` shows all episodes
- [x] `make 00-episode-data ARGS="show 19"` shows episode 19 details
- [x] `make 00-dump` exports all episodes to `src/dumps/`
- [x] `make 00-dump-schema` exports base schema (2 tables) to `src/dumps/`

Closes #31